### PR TITLE
Add Instagram token refresh script

### DIFF
--- a/auto-readme-generate/refresh-token.js
+++ b/auto-readme-generate/refresh-token.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+
+const TOKEN_REFRESH_URL = "https://graph.facebook.com/v20.0/oauth/access_token";
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+async function refreshToken() {
+  const clientId = getRequiredEnv("META_APP_ID");
+  const clientSecret = getRequiredEnv("META_APP_SECRET");
+  const currentToken = getRequiredEnv("INSTAGRAM_ACCESS_TOKEN");
+
+  const url = new URL(TOKEN_REFRESH_URL);
+  url.searchParams.set("grant_type", "fb_exchange_token");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("client_secret", clientSecret);
+  url.searchParams.set("fb_exchange_token", currentToken);
+
+  const response = await fetch(url);
+  const responseBody = await response.text();
+
+  if (!response.ok) {
+    console.error(`Token refresh failed with status ${response.status}.`);
+    console.error(responseBody);
+    throw new Error("Failed to refresh Instagram access token.");
+  }
+
+  const data = JSON.parse(responseBody);
+  const newToken = data.access_token;
+
+  if (!newToken) {
+    throw new Error("Token refresh response did not include access_token.");
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `new_token=${newToken}\n`);
+  } else {
+    console.log("Instagram access token refreshed successfully.");
+  }
+}
+
+refreshToken().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide a safe, automated way to exchange the existing Instagram access token for a refreshed token via the Meta Graph API while preventing accidental token leakage in local runs.

### Description
- Add `auto-readme-generate/refresh-token.js` which performs the token exchange against `https://graph.facebook.com/v20.0/oauth/access_token`.
- Validate required environment variables `META_APP_ID`, `META_APP_SECRET`, and `INSTAGRAM_ACCESS_TOKEN` using `getRequiredEnv` before making the request.
- Build the request with query parameters `grant_type=fb_exchange_token`, `client_id`, `client_secret`, and `fb_exchange_token`, then parse the JSON `access_token` from the response.
- Log non-2xx responses (status and response body) to `console.error` and throw to fail the process, and write `new_token={access_token}` to `GITHUB_OUTPUT` when present while avoiding printing the token during local runs.

### Testing
- Ran `node --check auto-readme-generate/refresh-token.js` which passed syntax checking.
- Ran the project test command `npm test` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b1935fd4c83209230961664d95a2b)