### PR TITLE
Add Instagram token refresh and secret update to README workflow

### DIFF
--- a/.github/workflows/readme-periodical-update.yml
+++ b/.github/workflows/readme-periodical-update.yml
@@ -28,8 +28,22 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Refresh Instagram Token
+        id: refresh-instagram-token
+        run: node auto-readme-generate/refresh-token.js
+        env:
+          META_APP_ID: ${{ secrets.META_APP_ID }}
+          META_APP_SECRET: ${{ secrets.META_APP_SECRET }}
+          INSTAGRAM_ACCESS_TOKEN: ${{ secrets.INSTAGRAM_ACCESS_TOKEN }}
+      - name: Update GitHub Secret
+        run: gh secret set INSTAGRAM_ACCESS_TOKEN --body "${{ steps.refresh-instagram-token.outputs.new_token }}"
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Generate README
         run: npm run generate
+        env:
+          INSTAGRAM_BUSINESS_ACCOUNT_ID: ${{ secrets.INSTAGRAM_BUSINESS_ACCOUNT_ID }}
+          INSTAGRAM_ACCESS_TOKEN: ${{ steps.refresh-instagram-token.outputs.new_token }}
       - name: Commit and push changes
         shell: bash
         run: |


### PR DESCRIPTION
### Motivation
- Ensure the Instagram access token used for README generation is refreshed automatically before generating the README.
- Persist the refreshed token back into GitHub Secrets so subsequent workflow runs use the new token.
- Keep the existing README-only commit/push flow unchanged.

### Description
- Added a `Refresh Instagram Token` step after `Install dependencies` that runs `node auto-readme-generate/refresh-token.js` and is given `id: refresh-instagram-token` and the env vars `META_APP_ID`, `META_APP_SECRET`, and `INSTAGRAM_ACCESS_TOKEN` from GitHub Secrets.
- Added an `Update GitHub Secret` step that runs `gh secret set INSTAGRAM_ACCESS_TOKEN --body "${{ steps.refresh-instagram-token.outputs.new_token }}"` with `GH_TOKEN` provided from `secrets.PERSONAL_ACCESS_TOKEN`.
- Updated the `Generate README` step to receive `INSTAGRAM_BUSINESS_ACCOUNT_ID` and `INSTAGRAM_ACCESS_TOKEN: ${{ steps.refresh-instagram-token.outputs.new_token }}` via `env`.
- Preserved the existing `Commit and push changes` step that only stages, commits, and pushes `README.md` when it has changed.

### Testing
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b1937d8308320a622cb344786eee9)